### PR TITLE
Added player health to player object and updated how bandage healing …

### DIFF
--- a/Assets/Scripts/HUD/HUD.cs
+++ b/Assets/Scripts/HUD/HUD.cs
@@ -91,7 +91,7 @@ public class HUD : MonoBehaviour
             healthBar.rectTransform.sizeDelta = new Vector2(healthBarCurrentWidth, healthBar.rectTransform.rect.height);
 
             // If damage has been take since last update
-            if(currentHealth != lastHealth)
+            if(currentHealth < lastHealth)
             {
                 healthFlash.fadeIn();
             }

--- a/Assets/Scripts/Items/Bandage.cs
+++ b/Assets/Scripts/Items/Bandage.cs
@@ -22,7 +22,7 @@ public class Bandage : MonoBehaviour, IPlayerItem
     // Expends a bandage
     public void UseBandage()
     {
-        numberOfBandages--;
+       numberOfBandages--;
     }
 
     public bool HasBandages()

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -3,6 +3,9 @@ using UnityEngine;
 
 public class Player : MonoBehaviour
 {
+    // All information reguarding player health
+    public PlayerHealth health;
+
     // Primary weapon
     public GameObject primaryWeapon;
 
@@ -31,12 +34,12 @@ public class Player : MonoBehaviour
 
     // Start is called before the first frame update
     void Start()
-    {
-        // Set player health
-        playerHealth = playerMaximumHealth;
-
+    {        
         // Hide all items other than selected.
-        HideItems();               
+        HideItems();
+
+        // Get the health script
+        health = GetComponent<PlayerHealth>();
     }
 
     // Update is called once per frame
@@ -117,7 +120,7 @@ public class Player : MonoBehaviour
                     timeElapsed = 0.0f;
                 }
             }
-            else if (HasBandagesSelected() && playerHealth < playerMaximumHealth)
+            else if (HasBandagesSelected())
             {
                 Bandage bandage = selectedItem.GetComponent<Bandage>();
                 StartCoroutine(UseBandage(bandage));
@@ -206,7 +209,7 @@ public class Player : MonoBehaviour
     // Uses a bandage if the player chooses to do so
     private IEnumerator UseBandage(Bandage bandage)
     {
-        if (bandage.HasBandages())
+        if (bandage.HasBandages() && health.getCurrentHealth() < health.getMaxHealth())
         {
             // Break if player is already bandaging
             if (isBandaging)
@@ -218,7 +221,7 @@ public class Player : MonoBehaviour
             PlaySound(bandage.useBandageSound);
             yield return new WaitForSeconds(bandage.timeToBandage);
             bandage.UseBandage();
-            playerHealth = playerHealth + bandage.bandageHealAmount > playerMaximumHealth ? playerMaximumHealth : playerHealth += bandage.bandageHealAmount;
+            SendMessage("heal", bandage.bandageHealAmount);
             isBandaging = false;
         }
         else

--- a/Assets/Scripts/PlayerHealth.cs
+++ b/Assets/Scripts/PlayerHealth.cs
@@ -18,6 +18,11 @@ public class PlayerHealth : MonoBehaviour
         checkHealth();
     }
 
+    public void heal(float amount)
+    {
+        currentHealth = currentHealth + amount > maxHealth ? maxHealth : currentHealth + amount;
+    }
+
 
     private void checkHealth()
     {

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -95,7 +95,7 @@ QualitySettings:
     skinWeights: 2
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 2
+    antiAliasing: 0
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 1


### PR DESCRIPTION
# Changes
There was some conflicts between our last two branches (should be fixed) as I implemented player health as well. I removed mine and kept yours.

## Commit 2
- Changed `if(currentHealth != lastHealth)` to `if(currentHealth < lastHealth)` in HUD script to stop damage screen flash happening on bandage use.

## Player
- Added PlayerHealth script to the player object.
- Added property `health` of type PlayerHealth and assigned it in the start method.

## PlayerHealth Script
- Added a new method `heal(float amount)` to apply the healing from a bandage.
